### PR TITLE
Set GameScene as entry view

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ath_speed_trainerApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            GameScene()
         }
     }
 }


### PR DESCRIPTION
## Summary
- show GameScene when the app launches

## Testing
- `swift --version`
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688a32b97720832fa6360fbdd11e4327