### PR TITLE
feat: add content view for screen navigation

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -1,24 +1,57 @@
-//
-//  ContentView.swift
-//  ath-speed-trainer
-//
-//  Created by 小林　景大 on 2025/07/30.
-//
-
 import SwiftUI
 
+/// アプリ全体の画面遷移を管理するトップレベルビュー
 struct ContentView: View {
+    /// 表示する画面の種類
+    enum AppScreen {
+        case modeSelect
+        case difficultySelect
+        case game
+        case result
+    }
+
+    /// 現在表示中の画面
+    @State private var currentScreen: AppScreen = .modeSelect
+
+    /// 選択されたゲームモード
+    @State private var selectedMode: GameMode?
+
+    /// 選択された難易度
+    @State private var selectedDifficulty: Difficulty?
+
+    /// 選択された出題形式
+    @State private var selectedStyle: QuestionStyle?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        switch currentScreen {
+        case .modeSelect:
+            ModeSelectView(selectedMode: $selectedMode)
+                .onChange(of: selectedMode) { _, newValue in
+                    if newValue != nil {
+                        currentScreen = .difficultySelect
+                    }
+                }
+
+        case .difficultySelect:
+            DifficultySelectView(
+                selectedDifficulty: $selectedDifficulty,
+                selectedStyle: $selectedStyle,
+                startGame: {
+                    currentScreen = .game
+                }
+            )
+
+        case .game:
+            GameScene()
+
+        case .result:
+            // TODO: 実装予定のリザルト画面
+            Text("ResultView")
         }
-        .padding()
     }
 }
 
 #Preview {
     ContentView()
 }
+

--- a/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct ath_speed_trainerApp: App {
     var body: some Scene {
         WindowGroup {
-            GameScene()
+            ContentView()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add ContentView to manage screen transitions
- show ContentView at app launch

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d8a1ef808832f8dd1483399269490