### PR TITLE
Add settings view for audio preferences

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+typealias AppScreen = ContentView.AppScreen
+
+struct SettingView: View {
+    @Binding var currentScreen: AppScreen
+    @AppStorage("isBgmOn") private var isBgmOn: Bool = true
+    @AppStorage("isSeOn") private var isSeOn: Bool = true
+
+    var body: some View {
+        VStack(spacing: 40) {
+            Text("設定")
+                .font(.largeTitle)
+                .padding(.top, 40)
+
+            VStack(spacing: 20) {
+                Toggle("BGM", isOn: $isBgmOn)
+                    .font(.title2)
+                Toggle("効果音（SE）", isOn: $isSeOn)
+                    .font(.title2)
+            }
+            .padding(.horizontal, 40)
+
+            Button("メニューに戻る") {
+                currentScreen = .modeSelect
+            }
+            .font(.title2)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.gray.opacity(0.2))
+            .cornerRadius(8)
+            .padding(.horizontal, 40)
+
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    SettingView(currentScreen: .constant(.modeSelect))
+}


### PR DESCRIPTION
## Summary
- add `SettingView` with BGM and SE toggles using `@AppStorage`
- include navigation back to the mode select menu

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d8e106200832f8eb5374f1a44966b