### PR TITLE
Refactor AppScreen to global enum

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -2,14 +2,6 @@ import SwiftUI
 
 /// アプリ全体の画面遷移を管理するトップレベルビュー
 struct ContentView: View {
-    /// 表示する画面の種類
-    enum AppScreen {
-        case modeSelect
-        case difficultySelect
-        case game
-        case result
-    }
-
     /// 現在表示中の画面
     @State private var currentScreen: AppScreen = .modeSelect
 
@@ -47,6 +39,12 @@ struct ContentView: View {
         case .result:
             // TODO: 実装予定のリザルト画面
             Text("ResultView")
+
+        case .setting:
+            SettingView(currentScreen: $currentScreen)
+
+        case .credit:
+            CreditView(currentScreen: $currentScreen)
         }
     }
 }

--- a/ath-speed-trainer/ath-speed-trainer/Models/AppScreen.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Models/AppScreen.swift
@@ -1,0 +1,8 @@
+enum AppScreen {
+    case modeSelect
+    case difficultySelect
+    case game
+    case result
+    case setting
+    case credit
+}

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-typealias AppScreen = ContentView.AppScreen
-
 struct CreditView: View {
     @Binding var currentScreen: AppScreen
 
@@ -49,6 +47,6 @@ struct CreditView: View {
 }
 
 #Preview {
-    CreditView(currentScreen: .constant(.setting))
+    CreditView(currentScreen: .constant(AppScreen.setting))
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-typealias AppScreen = ContentView.AppScreen
-
 struct ResultView: View {
     let score: Int
     let correctCount: Int
@@ -72,6 +70,6 @@ struct ResultView: View {
 }
 
 #Preview {
-    ResultView(score: 120, correctCount: 15, incorrectCount: 3, currentScreen: .constant(.result))
+    ResultView(score: 120, correctCount: 15, incorrectCount: 3, currentScreen: .constant(AppScreen.result))
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-typealias AppScreen = ContentView.AppScreen
-
 struct SettingView: View {
     @Binding var currentScreen: AppScreen
     @AppStorage("isBgmOn") private var isBgmOn: Bool = true
@@ -37,5 +35,5 @@ struct SettingView: View {
 }
 
 #Preview {
-    SettingView(currentScreen: .constant(.modeSelect))
+    SettingView(currentScreen: .constant(AppScreen.modeSelect))
 }


### PR DESCRIPTION
## Summary
- Introduce shared `AppScreen` enum for screen navigation
- Update ContentView and other views to reference global `AppScreen`
- Fix previews to use `.constant(AppScreen.*)`

## Testing
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_688da6ed36c4832f8f627fb9049a5008