### PR TITLE
Implement difficulty-based arithmetic problem generation

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
             )
 
         case .game:
-            GameScene()
+            GameScene(difficulty: selectedDifficulty ?? .easy)
 
         case .result:
             // TODO: 実装予定のリザルト画面

--- a/ath-speed-trainer/ath-speed-trainer/GameLogic/ProblemGenerator.swift
+++ b/ath-speed-trainer/ath-speed-trainer/GameLogic/ProblemGenerator.swift
@@ -1,21 +1,36 @@
 import Foundation
 
+/// Generates arithmetic problems based on the selected difficulty and current score.
 struct ProblemGenerator {
-    static func generate() -> ArithmeticProblem {
+    static func generate(difficulty: Difficulty, score: Int) -> ArithmeticProblem {
         let operations = ["+", "-", "×", "÷"]
         let op = operations.randomElement()!
+
+        switch difficulty {
+        case .easy:
+            return generateEasyProblem(op: op)
+        case .normal:
+            return generateNormalProblem(op: op)
+        case .hard:
+            return generateHardProblem(op: op, score: score)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private static func generateEasyProblem(op: String) -> ArithmeticProblem {
         switch op {
         case "+":
-            let a = Int.random(in: 1...99)
-            let b = Int.random(in: 1...99)
+            let a = Int.random(in: 1...9)
+            let b = Int.random(in: 1...9)
             return ArithmeticProblem(question: "\(a) + \(b)", answer: a + b)
         case "-":
-            let a = Int.random(in: 1...99)
-            let b = Int.random(in: 1...99)
+            let a = Int.random(in: 1...9)
+            let b = Int.random(in: 1...9)
             return ArithmeticProblem(question: "\(a) - \(b)", answer: a - b)
         case "×":
-            let a = Int.random(in: 1...99)
-            let b = Int.random(in: 1...99)
+            let a = Int.random(in: 1...9)
+            let b = Int.random(in: 1...9)
             return ArithmeticProblem(question: "\(a) × \(b)", answer: a * b)
         default:
             let b = Int.random(in: 1...9)
@@ -24,4 +39,62 @@ struct ProblemGenerator {
             return ArithmeticProblem(question: "\(a) ÷ \(b)", answer: ans)
         }
     }
+
+    private static func generateNormalProblem(op: String) -> ArithmeticProblem {
+        switch op {
+        case "+":
+            let a = Int.random(in: 10...99)
+            let b = Int.random(in: 10...99)
+            return ArithmeticProblem(question: "\(a) + \(b)", answer: a + b)
+        case "-":
+            let a = Int.random(in: 10...99)
+            let b = Int.random(in: 10...99)
+            return ArithmeticProblem(question: "\(a) - \(b)", answer: a - b)
+        case "×":
+            let a = Int.random(in: 1...9)
+            let b = Int.random(in: 1...9)
+            return ArithmeticProblem(question: "\(a) × \(b)", answer: a * b)
+        default:
+            let b = Int.random(in: 1...9)
+            let ans = Int.random(in: 1...9)
+            let a = b * ans
+            return ArithmeticProblem(question: "\(a) ÷ \(b)", answer: ans)
+        }
+    }
+
+    private static func generateHardProblem(op: String, score: Int) -> ArithmeticProblem {
+        switch op {
+        case "+":
+            let a = Int.random(in: 100...999)
+            let b = Int.random(in: 100...999)
+            return ArithmeticProblem(question: "\(a) + \(b)", answer: a + b)
+        case "-":
+            let a = Int.random(in: 100...999)
+            let b = Int.random(in: 100...999)
+            return ArithmeticProblem(question: "\(a) - \(b)", answer: a - b)
+        case "×":
+            if score > 70 {
+                let a = Int.random(in: 10...99)
+                let b = Int.random(in: 10...99)
+                return ArithmeticProblem(question: "\(a) × \(b)", answer: a * b)
+            } else {
+                let a = Int.random(in: 1...9)
+                let b = Int.random(in: 1...9)
+                return ArithmeticProblem(question: "\(a) × \(b)", answer: a * b)
+            }
+        default:
+            if score > 70 {
+                let b = Int.random(in: 10...99)
+                let ans = Int.random(in: 10...99)
+                let a = b * ans
+                return ArithmeticProblem(question: "\(a) ÷ \(b)", answer: ans)
+            } else {
+                let b = Int.random(in: 1...9)
+                let ans = Int.random(in: 1...9)
+                let a = b * ans
+                return ArithmeticProblem(question: "\(a) ÷ \(b)", answer: ans)
+            }
+        }
+    }
 }
+

--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import AVFoundation
 
 final class GameSceneViewModel: ObservableObject {
-    @Published var problem: ArithmeticProblem = ProblemGenerator.generate()
+    @Published var problem: ArithmeticProblem
     @Published var userInput: String = ""
     @Published var score: Int = 0
     @Published var timeRemaining: Int = 30
@@ -10,7 +10,13 @@ final class GameSceneViewModel: ObservableObject {
 
     enum Feedback { case correct, wrong }
 
+    private let difficulty: Difficulty
     private var timer: Timer?
+
+    init(difficulty: Difficulty) {
+        self.difficulty = difficulty
+        self.problem = ProblemGenerator.generate(difficulty: difficulty, score: 0)
+    }
 
     func startGame() {
         timer?.invalidate()
@@ -18,7 +24,7 @@ final class GameSceneViewModel: ObservableObject {
         score = 0
         userInput = ""
         feedback = nil
-        problem = ProblemGenerator.generate()
+        problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             guard let self else { return }
             self.timeRemaining -= 1
@@ -45,7 +51,7 @@ final class GameSceneViewModel: ObservableObject {
             timeRemaining += 2
             feedback = .correct
             AudioServicesPlaySystemSound(1057)
-            problem = ProblemGenerator.generate()
+            problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
             userInput = ""
         } else {
             score -= 5

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -2,7 +2,11 @@ import SwiftUI
 import AVFoundation
 
 struct GameScene: View {
-    @StateObject private var viewModel = GameSceneViewModel()
+    @StateObject private var viewModel: GameSceneViewModel
+
+    init(difficulty: Difficulty) {
+        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty))
+    }
 
     var body: some View {
         VStack(spacing: 20) {
@@ -67,5 +71,5 @@ struct GameScene: View {
 }
 
 #Preview {
-    GameScene()
+    GameScene(difficulty: .easy)
 }


### PR DESCRIPTION
## Summary
- Add difficulty-aware problem generator that adjusts operand ranges and upgrades hard multiplication/division after score exceeds 70
- Inject selected difficulty into game scene and view model to drive score-based problem generation

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc -typecheck ath-speed-trainer/ath-speed-trainer/Models/ArithmeticProblem.swift ath-speed-trainer/ath-speed-trainer/Models/Difficulty.swift ath-speed-trainer/ath-speed-trainer/GameLogic/ProblemGenerator.swift`
- `swiftc -typecheck ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_688dae956e6c832f8a56e45d110b8f7d