### PR TITLE
Add consistent back navigation across app views

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -34,7 +34,7 @@ struct ContentView: View {
             )
 
         case .game:
-            GameScene(difficulty: selectedDifficulty ?? .easy)
+            GameScene(difficulty: selectedDifficulty ?? .easy, currentScreen: $currentScreen)
 
         case .result:
             // TODO: 実装予定のリザルト画面

--- a/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct BackButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        HStack {
+            Button("\uFF1C\u623B\u308B", action: action)
+                .font(.title3)
+            Spacer()
+        }
+        .padding(.top, 16)
+        .padding(.leading, 16)
+    }
+}
+
+#Preview {
+    BackButton {}
+}

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -4,44 +4,37 @@ struct CreditView: View {
     @Binding var currentScreen: AppScreen
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("Ath Speed Trainer")
-                    .font(.title)
-                    .padding(.top, 40)
+        VStack(alignment: .leading, spacing: 20) {
+            BackButton { currentScreen = .setting }
 
-                Group {
-                    Text("開発者")
-                        .font(.headline)
-                    Text("Keita Kobayashi")
-                }
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Ath Speed Trainer")
+                        .font(.title)
 
-                Group {
-                    Text("使用素材")
-                        .font(.headline)
-                    Text("アイコン：Flaticon\n効果音：効果音ラボ")
-                        .multilineTextAlignment(.leading)
-                }
+                    Group {
+                        Text("開発者")
+                            .font(.headline)
+                        Text("Keita Kobayashi")
+                    }
 
-                Group {
-                    Text("ライセンス")
-                        .font(.headline)
-                    Text("このアプリはMITライセンスに基づいて公開されています。\n使用素材の著作権は各提供元に帰属します。")
-                        .multilineTextAlignment(.leading)
-                }
+                    Group {
+                        Text("使用素材")
+                            .font(.headline)
+                        Text("アイコン：Flaticon\n効果音：効果音ラボ")
+                            .multilineTextAlignment(.leading)
+                    }
 
-                Button("設定に戻る") {
-                    currentScreen = .setting
+                    Group {
+                        Text("ライセンス")
+                            .font(.headline)
+                        Text("このアプリはMITライセンスに基づいて公開されています。\n使用素材の著作権は各提供元に帰属します。")
+                            .multilineTextAlignment(.leading)
+                    }
                 }
-                .font(.title2)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.gray.opacity(0.2))
-                .cornerRadius(8)
-                .padding(.top, 40)
+                .padding(.horizontal, 40)
                 .padding(.bottom, 40)
             }
-            .padding(.horizontal, 40)
         }
     }
 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -2,14 +2,21 @@ import SwiftUI
 import AVFoundation
 
 struct GameScene: View {
+    @Binding var currentScreen: AppScreen
     @StateObject private var viewModel: GameSceneViewModel
 
-    init(difficulty: Difficulty) {
+    init(difficulty: Difficulty, currentScreen: Binding<AppScreen>) {
         _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty))
+        self._currentScreen = currentScreen
     }
 
     var body: some View {
         VStack(spacing: 20) {
+            BackButton {
+                viewModel.stopGame()
+                currentScreen = .difficultySelect
+            }
+
             HStack {
                 Text("Score: \(viewModel.score)")
                 Spacer()
@@ -71,5 +78,5 @@ struct GameScene: View {
 }
 
 #Preview {
-    GameScene(difficulty: .easy)
+    GameScene(difficulty: .easy, currentScreen: .constant(.game))
 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -22,47 +22,41 @@ struct ResultView: View {
     }
 
     var body: some View {
-        VStack(spacing: 40) {
-            Text("結果発表")
-                .font(.largeTitle)
-                .padding(.top, 40)
+        VStack(spacing: 20) {
+            BackButton { currentScreen = .modeSelect }
 
-            VStack(spacing: 20) {
-                Text("スコア: \(score)点")
-                    .font(.title2)
-                Text("\(correctCount)問正解")
-                    .font(.title2)
-                if let incorrectCount {
-                    Text("\(incorrectCount)問不正解")
+            VStack(spacing: 40) {
+                Text("結果発表")
+                    .font(.largeTitle)
+
+                VStack(spacing: 20) {
+                    Text("スコア: \(score)点")
                         .font(.title2)
+                    Text("\(correctCount)問正解")
+                        .font(.title2)
+                    if let incorrectCount {
+                        Text("\(incorrectCount)問不正解")
+                            .font(.title2)
+                    }
+                    if let highScore {
+                        Text("ハイスコア: \(highScore)点")
+                            .font(.title3)
+                            .padding(.top, 10)
+                    }
                 }
-                if let highScore {
-                    Text("ハイスコア: \(highScore)点")
-                        .font(.title3)
-                        .padding(.top, 10)
-                }
-            }
 
-            VStack(spacing: 20) {
-                Button("もう一度プレイ") {
-                    currentScreen = .game
+                VStack(spacing: 20) {
+                    Button("もう一度プレイ") {
+                        currentScreen = .game
+                    }
+                    .font(.title2)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue.opacity(0.2))
+                    .cornerRadius(8)
                 }
-                .font(.title2)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.blue.opacity(0.2))
-                .cornerRadius(8)
-
-                Button("モード選択へ戻る") {
-                    currentScreen = .modeSelect
-                }
-                .font(.title2)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.gray.opacity(0.2))
-                .cornerRadius(8)
+                .padding(.horizontal, 40)
             }
-            .padding(.horizontal, 40)
 
             Spacer()
         }

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -6,28 +6,21 @@ struct SettingView: View {
     @AppStorage("isSeOn") private var isSeOn: Bool = true
 
     var body: some View {
-        VStack(spacing: 40) {
-            Text("設定")
-                .font(.largeTitle)
-                .padding(.top, 40)
+        VStack(spacing: 20) {
+            BackButton { currentScreen = .modeSelect }
 
-            VStack(spacing: 20) {
-                Toggle("BGM", isOn: $isBgmOn)
-                    .font(.title2)
-                Toggle("効果音（SE）", isOn: $isSeOn)
-                    .font(.title2)
-            }
-            .padding(.horizontal, 40)
+            VStack(spacing: 40) {
+                Text("設定")
+                    .font(.largeTitle)
 
-            Button("メニューに戻る") {
-                currentScreen = .modeSelect
+                VStack(spacing: 20) {
+                    Toggle("BGM", isOn: $isBgmOn)
+                        .font(.title2)
+                    Toggle("効果音（SE）", isOn: $isSeOn)
+                        .font(.title2)
+                }
+                .padding(.horizontal, 40)
             }
-            .font(.title2)
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.gray.opacity(0.2))
-            .cornerRadius(8)
-            .padding(.horizontal, 40)
 
             Spacer()
         }


### PR DESCRIPTION
## Summary
- Introduce a reusable `BackButton` view to standardize back navigation styling.
- Add back buttons to Setting, Credit, Result, and Game screens; remove legacy return buttons.
- Pass `currentScreen` binding into `GameScene` and stop the game timer when leaving.

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688db1f7d778832fb7e6e092055d5e73