### PR TITLE
Fix result screen not appearing at game end

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -14,6 +14,11 @@ struct ContentView: View {
     /// 選択された出題形式
     @State private var selectedStyle: QuestionStyle?
 
+    /// ゲーム結果
+    @State private var finalScore: Int = 0
+    @State private var correctCount: Int = 0
+    @State private var incorrectCount: Int = 0
+
     var body: some View {
         switch currentScreen {
         case .modeSelect:
@@ -34,11 +39,24 @@ struct ContentView: View {
             )
 
         case .game:
-            GameScene(difficulty: selectedDifficulty ?? .easy, currentScreen: $currentScreen)
+            GameScene(
+                difficulty: selectedDifficulty ?? .easy,
+                currentScreen: $currentScreen,
+                onGameEnd: { score, correct, incorrect in
+                    finalScore = score
+                    correctCount = correct
+                    incorrectCount = incorrect
+                    currentScreen = .result
+                }
+            )
 
         case .result:
-            // TODO: 実装予定のリザルト画面
-            Text("ResultView")
+            ResultView(
+                score: finalScore,
+                correctCount: correctCount,
+                incorrectCount: incorrectCount,
+                currentScreen: $currentScreen
+            )
 
         case .setting:
             SettingView(currentScreen: $currentScreen)

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -5,8 +5,8 @@ struct GameScene: View {
     @Binding var currentScreen: AppScreen
     @StateObject private var viewModel: GameSceneViewModel
 
-    init(difficulty: Difficulty, currentScreen: Binding<AppScreen>) {
-        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty))
+    init(difficulty: Difficulty, currentScreen: Binding<AppScreen>, onGameEnd: @escaping (Int, Int, Int) -> Void) {
+        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty, onGameEnd: onGameEnd))
         self._currentScreen = currentScreen
     }
 
@@ -78,5 +78,5 @@ struct GameScene: View {
 }
 
 #Preview {
-    GameScene(difficulty: .easy, currentScreen: .constant(.game))
+    GameScene(difficulty: .easy, currentScreen: .constant(.game), onGameEnd: { _,_,_ in })
 }


### PR DESCRIPTION
## Summary
- propagate game-end stats from `GameSceneViewModel` to the main `ContentView`
- show `ResultView` with score and answer counts when the timer expires

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688db56826bc832f90ed895f32d8162a