### PR TITLE
Add settings and credit buttons to mode select view

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
     var body: some View {
         switch currentScreen {
         case .modeSelect:
-            ModeSelectView(selectedMode: $selectedMode)
+            ModeSelectView(currentScreen: $currentScreen, selectedMode: $selectedMode)
                 .onChange(of: selectedMode) { _, newValue in
                     if newValue != nil {
                         currentScreen = .difficultySelect

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ModeSelectView: View {
+    @Binding var currentScreen: AppScreen
     @Binding var selectedMode: GameMode?
 
     var body: some View {
@@ -17,6 +18,13 @@ struct ModeSelectView: View {
             .padding(.horizontal, 40)
 
             Spacer()
+
+            VStack(spacing: 20) {
+                menuButton(title: "設定", screen: .setting)
+                menuButton(title: "クレジット", screen: .credit)
+            }
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
         }
     }
 
@@ -30,9 +38,20 @@ struct ModeSelectView: View {
                 .cornerRadius(8)
         }
     }
+
+    private func menuButton(title: String, screen: AppScreen) -> some View {
+        Button(action: { currentScreen = screen }) {
+            Text(title)
+                .font(.title3)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.gray.opacity(0.2))
+                .cornerRadius(8)
+        }
+    }
 }
 
 #Preview {
-    ModeSelectView(selectedMode: .constant(nil))
+    ModeSelectView(currentScreen: .constant(.modeSelect), selectedMode: .constant(nil))
 }
 


### PR DESCRIPTION
## Summary
- add Settings and Credits menu buttons to the mode select screen
- wire mode select view to app-level navigation

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688db9b9f90c832fa847ae1d621a3035