### PR TITLE
Add menu navigation to difficulty and credit views

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -33,6 +33,7 @@ struct ContentView: View {
             DifficultySelectView(
                 selectedDifficulty: $selectedDifficulty,
                 selectedStyle: $selectedStyle,
+                currentScreen: $currentScreen,
                 startGame: {
                     currentScreen = .game
                 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -5,7 +5,15 @@ struct CreditView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            BackButton { currentScreen = .setting }
+            HStack {
+                Button("メニューに戻る") {
+                    currentScreen = .modeSelect
+                }
+                .font(.title3)
+                Spacer()
+            }
+            .padding(.top, 16)
+            .padding(.leading, 16)
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -40,6 +48,6 @@ struct CreditView: View {
 }
 
 #Preview {
-    CreditView(currentScreen: .constant(AppScreen.setting))
+    CreditView(currentScreen: .constant(AppScreen.modeSelect))
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DifficultySelectView: View {
     @Binding var selectedDifficulty: Difficulty?
     @Binding var selectedStyle: QuestionStyle?
+    @Binding var currentScreen: AppScreen
     var startGame: () -> Void
 
     var body: some View {
@@ -43,6 +44,16 @@ struct DifficultySelectView: View {
             .padding(.horizontal, 40)
 
             Spacer()
+
+            Button("メニューに戻る") {
+                currentScreen = .modeSelect
+            }
+            .font(.title2)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.gray.opacity(0.2))
+            .cornerRadius(8)
+            .padding(.horizontal, 40)
         }
     }
 
@@ -70,6 +81,11 @@ struct DifficultySelectView: View {
 }
 
 #Preview {
-    DifficultySelectView(selectedDifficulty: .constant(.easy), selectedStyle: .constant(.single), startGame: {})
+    DifficultySelectView(
+        selectedDifficulty: .constant(.easy),
+        selectedStyle: .constant(.single),
+        currentScreen: .constant(.modeSelect),
+        startGame: {}
+    )
 }
 


### PR DESCRIPTION
## Summary
- Add `currentScreen` binding and menu return button to difficulty selection view
- Route credit view's back button to menu and update label

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e1a204bd4832f9a4fa9ac2963c3e6