### PR TITLE
Add sign toggle button to keypad

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -50,10 +50,22 @@ final class GameSceneViewModel: ObservableObject {
         userInput.append(String(digit))
     }
 
+    func toggleSign() {
+        guard timeRemaining > 0 else { return }
+        if userInput.hasPrefix("-") {
+            userInput.removeFirst()
+        } else if !userInput.isEmpty {
+            userInput = "-" + userInput
+        }
+    }
+
     func deleteLastDigit() {
         guard timeRemaining > 0 else { return }
         guard !userInput.isEmpty else { return }
         userInput.removeLast()
+        if userInput == "-" {
+            userInput = ""
+        }
     }
 
     func submit() {

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -59,6 +59,13 @@ struct GameScene: View {
                 }
             }
             HStack(spacing: 10) {
+                Button(action: { viewModel.toggleSign() }) {
+                    Text("+/-")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .padding()
+                        .background(Color.gray.opacity(0.2))
+                        .cornerRadius(8)
+                }
                 Button(action: { viewModel.enterDigit(0) }) {
                     Text("0")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- allow input of negative answers by adding a new `+/-` toggle button on the keypad
- support toggling negative sign in `GameSceneViewModel`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e1bc61260832fb4831d1fc36a01dc