### PR TITLE
fix mode reselection

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -29,7 +29,12 @@ struct ModeSelectView: View {
     }
 
     private func modeButton(title: String, mode: GameMode) -> some View {
-        Button(action: { selectedMode = mode }) {
+        Button(action: {
+            selectedMode = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                selectedMode = mode
+            }
+        }) {
             Text(title)
                 .font(.title2)
                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- reset selected game mode before reassigning so mode re-selection triggers

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e20dd057c832f980e29ba303556b5