### PR TITLE
Add game-mode logic and result handling

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var finalScore: Int = 0
     @State private var correctCount: Int = 0
     @State private var incorrectCount: Int = 0
+    @State private var elapsedTime: Int = 0
 
     var body: some View {
         switch currentScreen {
@@ -42,20 +43,24 @@ struct ContentView: View {
         case .game:
             GameScene(
                 difficulty: selectedDifficulty ?? .easy,
+                mode: selectedMode ?? .timeAttack,
                 currentScreen: $currentScreen,
-                onGameEnd: { score, correct, incorrect in
+                onGameEnd: { score, correct, incorrect, time in
                     finalScore = score
                     correctCount = correct
-                    incorrectCount = incorrect
+                    incorrectCount = incorrect ?? 0
+                    elapsedTime = time
                     currentScreen = .result
                 }
             )
 
         case .result:
             ResultView(
+                mode: selectedMode ?? .timeAttack,
                 score: finalScore,
                 correctCount: correctCount,
-                incorrectCount: incorrectCount,
+                incorrectCount: selectedMode == .timeAttack ? incorrectCount : nil,
+                time: elapsedTime,
                 currentScreen: $currentScreen
             )
 

--- a/ath-speed-trainer/ath-speed-trainer/Models/GameMode.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Models/GameMode.swift
@@ -3,6 +3,6 @@ import Foundation
 enum GameMode {
     case timeAttack
     case correctCount
-    case suddenDeath
+    case noMistake
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -9,49 +9,81 @@ final class GameSceneViewModel: ObservableObject {
     @Published var feedback: Feedback? = nil
     @Published var correctCount: Int = 0
     @Published var incorrectCount: Int = 0
+    @Published var answeredCount: Int = 0
 
     enum Feedback { case correct, wrong }
 
     private let difficulty: Difficulty
+    private let mode: GameMode
     private var timer: Timer?
-    private let onGameEnd: ((Int, Int, Int) -> Void)?
+    private let questionLimit = 10
+    private var isGameOver = false
+    private let onGameEnd: ((Int, Int, Int?, Int) -> Void)?
 
-    init(difficulty: Difficulty, onGameEnd: ((Int, Int, Int) -> Void)? = nil) {
+    init(difficulty: Difficulty, mode: GameMode, onGameEnd: ((Int, Int, Int?, Int) -> Void)? = nil) {
         self.difficulty = difficulty
+        self.mode = mode
         self.onGameEnd = onGameEnd
         self.problem = ProblemGenerator.generate(difficulty: difficulty, score: 0)
     }
 
     func startGame() {
         timer?.invalidate()
-        timeRemaining = 30
         score = 0
         userInput = ""
         feedback = nil
         correctCount = 0
         incorrectCount = 0
+        answeredCount = 0
+        isGameOver = false
         problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard let self else { return }
-            self.timeRemaining -= 1
-            if self.timeRemaining <= 0 {
-                self.timer?.invalidate()
-                self.onGameEnd?(self.score, self.correctCount, self.incorrectCount)
+
+        switch mode {
+        case .timeAttack:
+            timeRemaining = 30
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                guard let self else { return }
+                self.timeRemaining -= 1
+                if self.timeRemaining <= 0 {
+                    self.endGame()
+                }
+            }
+        case .correctCount, .noMistake:
+            timeRemaining = 0
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                self?.timeRemaining += 1
             }
         }
     }
 
+    private func endGame() {
+        timer?.invalidate()
+        isGameOver = true
+        let time = timeRemaining
+        onGameEnd?(score, correctCount, mode == .timeAttack ? incorrectCount : nil, time)
+    }
+
     func stopGame() {
         timer?.invalidate()
+        isGameOver = true
+    }
+
+    private func canInput() -> Bool {
+        switch mode {
+        case .timeAttack:
+            return timeRemaining > 0
+        case .correctCount, .noMistake:
+            return !isGameOver
+        }
     }
 
     func enterDigit(_ digit: Int) {
-        guard timeRemaining > 0 else { return }
+        guard canInput() else { return }
         userInput.append(String(digit))
     }
 
     func toggleSign() {
-        guard timeRemaining > 0 else { return }
+        guard canInput() else { return }
         if userInput.hasPrefix("-") {
             userInput.removeFirst()
         } else if !userInput.isEmpty {
@@ -60,7 +92,7 @@ final class GameSceneViewModel: ObservableObject {
     }
 
     func deleteLastDigit() {
-        guard timeRemaining > 0 else { return }
+        guard canInput() else { return }
         guard !userInput.isEmpty else { return }
         userInput.removeLast()
         if userInput == "-" {
@@ -69,22 +101,42 @@ final class GameSceneViewModel: ObservableObject {
     }
 
     func submit() {
-        guard timeRemaining > 0 else { return }
+        guard canInput() else { return }
         guard let value = Int(userInput) else { return }
+
         if value == problem.answer {
-            score += 10
-            timeRemaining += 2
             feedback = .correct
             correctCount += 1
             AudioServicesPlaySystemSound(1057)
-            problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
-            userInput = ""
+            if mode == .timeAttack {
+                score += 10
+                timeRemaining += 2
+            }
         } else {
-            score -= 5
             feedback = .wrong
             incorrectCount += 1
             AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
-            userInput = ""
+            if mode == .timeAttack {
+                score -= 5
+            } else if mode == .noMistake {
+                endGame()
+                userInput = ""
+                return
+            }
+        }
+
+        answeredCount += 1
+        userInput = ""
+
+        if mode == .correctCount && answeredCount >= questionLimit {
+            endGame()
+            return
+        }
+
+        if mode == .timeAttack || mode == .correctCount {
+            problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
+        } else if mode == .noMistake && feedback == .correct {
+            problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
         }
     }
 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -5,8 +5,8 @@ struct GameScene: View {
     @Binding var currentScreen: AppScreen
     @StateObject private var viewModel: GameSceneViewModel
 
-    init(difficulty: Difficulty, currentScreen: Binding<AppScreen>, onGameEnd: @escaping (Int, Int, Int) -> Void) {
-        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty, onGameEnd: onGameEnd))
+    init(difficulty: Difficulty, mode: GameMode, currentScreen: Binding<AppScreen>, onGameEnd: @escaping (Int, Int, Int?, Int) -> Void) {
+        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty, mode: mode, onGameEnd: onGameEnd))
         self._currentScreen = currentScreen
     }
 
@@ -92,5 +92,5 @@ struct GameScene: View {
 }
 
 #Preview {
-    GameScene(difficulty: .easy, currentScreen: .constant(.game), onGameEnd: { _,_,_ in })
+    GameScene(difficulty: .easy, mode: .timeAttack, currentScreen: .constant(.game), onGameEnd: { _,_,_,_ in })
 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -13,7 +13,7 @@ struct ModeSelectView: View {
             VStack(spacing: 20) {
                 modeButton(title: "タイムアタック", mode: .timeAttack)
                 modeButton(title: "正解数チャレンジ", mode: .correctCount)
-                modeButton(title: "ミス耐久", mode: .suddenDeath)
+                modeButton(title: "ミス耐久", mode: .noMistake)
             }
             .padding(.horizontal, 40)
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -1,23 +1,29 @@
 import SwiftUI
 
 struct ResultView: View {
+    let mode: GameMode
     let score: Int
     let correctCount: Int
     let incorrectCount: Int?
+    let time: Int
     @Binding var currentScreen: AppScreen
     @State private var highScore: Int?
 
-    init(score: Int, correctCount: Int, incorrectCount: Int? = nil, currentScreen: Binding<AppScreen>) {
+    init(mode: GameMode, score: Int, correctCount: Int, incorrectCount: Int? = nil, time: Int = 0, currentScreen: Binding<AppScreen>) {
+        self.mode = mode
         self.score = score
         self.correctCount = correctCount
         self.incorrectCount = incorrectCount
+        self.time = time
         self._currentScreen = currentScreen
-        let saved = UserDefaults.standard.object(forKey: "HighScore") as? Int
-        if let saved, saved >= score {
-            _highScore = State(initialValue: saved)
-        } else {
-            UserDefaults.standard.set(score, forKey: "HighScore")
-            _highScore = State(initialValue: score)
+        if mode == .timeAttack {
+            let saved = UserDefaults.standard.object(forKey: "HighScore") as? Int
+            if let saved, saved >= score {
+                _highScore = State(initialValue: saved)
+            } else {
+                UserDefaults.standard.set(score, forKey: "HighScore")
+                _highScore = State(initialValue: score)
+            }
         }
     }
 
@@ -30,18 +36,29 @@ struct ResultView: View {
                     .font(.largeTitle)
 
                 VStack(spacing: 20) {
-                    Text("スコア: \(score)点")
-                        .font(.title2)
-                    Text("\(correctCount)問正解")
-                        .font(.title2)
-                    if let incorrectCount {
-                        Text("\(incorrectCount)問不正解")
+                    switch mode {
+                    case .timeAttack:
+                        Text("スコア: \(score)点")
                             .font(.title2)
-                    }
-                    if let highScore {
-                        Text("ハイスコア: \(highScore)点")
-                            .font(.title3)
-                            .padding(.top, 10)
+                        Text("\(correctCount)問正解")
+                            .font(.title2)
+                        if let incorrectCount {
+                            Text("\(incorrectCount)問不正解")
+                                .font(.title2)
+                        }
+                        if let highScore {
+                            Text("ハイスコア: \(highScore)点")
+                                .font(.title3)
+                                .padding(.top, 10)
+                        }
+                    case .correctCount:
+                        Text("\(correctCount)問正解")
+                            .font(.title2)
+                        Text("時間: \(time)秒")
+                            .font(.title2)
+                    case .noMistake:
+                        Text("\(correctCount)問正解")
+                            .font(.title2)
                     }
                 }
 
@@ -64,6 +81,6 @@ struct ResultView: View {
 }
 
 #Preview {
-    ResultView(score: 120, correctCount: 15, incorrectCount: 3, currentScreen: .constant(AppScreen.result))
+    ResultView(mode: .timeAttack, score: 120, correctCount: 15, incorrectCount: 3, time: 30, currentScreen: .constant(AppScreen.result))
 }
 


### PR DESCRIPTION
## Summary
- add `noMistake` mode and propagate game mode through view hierarchy
- implement mode-specific timers, scoring and end conditions
- show mode-appropriate results and elapsed time

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e29a9a350832fa1a7ecaa5b88aa01