### PR TITLE
Generalize countdown for pause menu actions

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -63,11 +63,14 @@ struct GameScene: View {
                     .ignoresSafeArea()
                 VStack(spacing: 20) {
                     Button("再開") {
-                        startCountdown()
+                        startCountdown {
+                            viewModel.resumeGame()
+                        }
                     }
                     Button("リセット") {
-                        viewModel.startGame()
-                        showPauseMenu = false
+                        startCountdown {
+                            viewModel.startGame()
+                        }
                     }
                     Button("メニューに戻る") {
                         viewModel.stopGame()
@@ -148,14 +151,14 @@ struct GameScene: View {
         }
     }
 
-    private func startCountdown() {
+    private func startCountdown(completion: @escaping () -> Void) {
         countdown = 3
         showPauseMenu = false
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
             countdown -= 1
             if countdown == 0 {
                 timer.invalidate()
-                viewModel.resumeGame()
+                completion()
             }
         }
     }


### PR DESCRIPTION
## Summary
- refactor countdown to accept completion closure
- apply countdown to both resume and reset actions in pause menu

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project ath-speed-trainer/ath-speed-trainer.xcodeproj -scheme ath-speed-trainer -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac204204832f88a9437cfa9f127f