### PR TITLE
Fix keypad position shifting during input

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -27,14 +27,21 @@ struct GameScene: View {
                 Text(viewModel.problem.question)
                     .font(.largeTitle)
 
-                if let feedback = viewModel.feedback {
-                    Image(systemName: feedback == .correct ? "checkmark.circle" : "xmark.circle")
-                        .foregroundColor(feedback == .correct ? .green : .red)
-                        .font(.system(size: 50))
+                Group {
+                    if let feedback = viewModel.feedback {
+                        Image(systemName: feedback == .correct ? "checkmark.circle" : "xmark.circle")
+                            .foregroundColor(feedback == .correct ? .green : .red)
+                    } else {
+                        Image(systemName: "checkmark.circle")
+                            .opacity(0)
+                    }
                 }
+                .font(.system(size: 50))
+                .frame(height: 60)
 
                 Text(viewModel.userInput)
                     .font(.title)
+                    .frame(height: 40)
 
                 keypad
             }


### PR DESCRIPTION
## Summary
- keep feedback image height constant to prevent keypad jumping
- fix user input text area to a constant height

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894ad67edb0832f88107af59f496c41