### PR TITLE
Update correct count mode label

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -17,7 +17,7 @@ struct GameScene: View {
     private var modeLabel: String {
         switch mode {
         case .timeAttack: return "タイムアタック"
-        case .correctCount: return "正解数チャレンジ"
+        case .correctCount: return "10問正解タイムアタック"
         case .noMistake: return "ミス耐久"
         }
     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -12,7 +12,7 @@ struct ModeSelectView: View {
 
             VStack(spacing: 20) {
                 modeButton(title: "タイムアタック", mode: .timeAttack)
-                modeButton(title: "正解数チャレンジ", mode: .correctCount)
+                modeButton(title: "10問正解タイムアタック", mode: .correctCount)
                 modeButton(title: "ミス耐久", mode: .noMistake)
             }
             .padding(.horizontal, 40)

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -27,13 +27,25 @@ struct ResultView: View {
         }
     }
 
+    private var modeLabel: String {
+        switch mode {
+        case .timeAttack: return "タイムアタック"
+        case .correctCount: return "10問正解タイムアタック"
+        case .noMistake: return "ミス耐久"
+        }
+    }
+
     var body: some View {
         VStack(spacing: 20) {
             BackButton { currentScreen = .modeSelect }
 
             VStack(spacing: 40) {
-                Text("結果発表")
-                    .font(.largeTitle)
+                VStack(spacing: 20) {
+                    Text("結果発表")
+                        .font(.largeTitle)
+                    Text(modeLabel)
+                        .font(.title2)
+                }
 
                 VStack(spacing: 20) {
                     switch mode {


### PR DESCRIPTION
## Summary
- rename correctCount mode to "10問正解タイムアタック" in mode selector
- show new mode label in-game and on result screen

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6894afa8897c832f8cb7c3c8c88310a8