### PR TITLE
Show app title on mode selection screen

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -5,10 +5,15 @@ struct ModeSelectView: View {
     @Binding var selectedMode: GameMode?
 
     var body: some View {
-        VStack(spacing: 40) {
-            Text("モード選択")
+        VStack {
+            Text("Ath Speed Trainer")
                 .font(.largeTitle)
+                .bold()
                 .padding(.top, 40)
+
+            Text("モード選択")
+                .font(.title2)
+                .padding(.top, 10)
 
             VStack(spacing: 20) {
                 modeButton(title: "タイムアタック", mode: .timeAttack)
@@ -16,6 +21,7 @@ struct ModeSelectView: View {
                 modeButton(title: "ミス耐久", mode: .noMistake)
             }
             .padding(.horizontal, 40)
+            .padding(.top, 20)
 
             Spacer()
 


### PR DESCRIPTION
## Summary
- Display the application title along with mode selection options in a single screen.
- Tone down the previous mode selection title to a smaller heading.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894b24527f0832fa79ed0753416215e