### PR TITLE
Disable Enter when input empty

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -169,6 +169,8 @@ struct GameScene: View {
                     .cornerRadius(8)
             }
             .contentShape(Rectangle())
+            .disabled(viewModel.userInput.isEmpty)
+            .opacity(viewModel.userInput.isEmpty ? 0.4 : 1.0)
         }
     }
 


### PR DESCRIPTION
## Summary
- Prevent submitting with empty input by disabling Enter

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894b60a8ee0832f8ae813bafb51f8e7