### PR TITLE
Add combo streak overlay in time attack mode

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -13,6 +13,8 @@ final class GameSceneViewModel: ObservableObject {
     @Published var scoreDelta: Int? = nil
     @Published var timeDelta: Int? = nil
     @Published var isPaused: Bool = false
+    @Published var comboCount: Int = 0
+    @Published var showCombo: Bool = false
 
     @AppStorage("isSeOn") private var isSeOn: Bool = true
     @AppStorage("isVibrationOn") private var isVibrationOn: Bool = true
@@ -41,6 +43,8 @@ final class GameSceneViewModel: ObservableObject {
         correctCount = 0
         incorrectCount = 0
         answeredCount = 0
+        comboCount = 0
+        showCombo = false
         isGameOver = false
         isPaused = false
         problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
@@ -139,6 +143,15 @@ final class GameSceneViewModel: ObservableObject {
                 AudioServicesPlaySystemSound(1057)
             }
             if mode == .timeAttack {
+                comboCount += 1
+                showCombo = comboCount >= 2
+                if showCombo {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        withAnimation {
+                            self.showCombo = false
+                        }
+                    }
+                }
                 withAnimation {
                     score += 10
                     timeRemaining += 2
@@ -146,6 +159,9 @@ final class GameSceneViewModel: ObservableObject {
                     timeDelta = 2
                 }
                 clearDeltasAfterDelay()
+            } else {
+                comboCount = 0
+                showCombo = false
             }
 
             answeredCount += 1
@@ -161,6 +177,8 @@ final class GameSceneViewModel: ObservableObject {
         } else {
             feedback = .wrong
             incorrectCount += 1
+            comboCount = 0
+            showCombo = false
             if isVibrationOn {
                 AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
             }

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -110,7 +110,19 @@ struct GameScene: View {
                     .font(.system(size: 60))
                     .foregroundColor(.white)
             }
+
+            if viewModel.showCombo {
+                Text("連続\(viewModel.comboCount)問正解！")
+                    .font(.title2)
+                    .foregroundColor(.orange)
+                    .padding()
+                    .background(Color.white.opacity(0.8))
+                    .cornerRadius(10)
+                    .transition(.scale)
+                    .zIndex(1)
+            }
         }
+        .animation(.easeInOut, value: viewModel.comboCount)
         .onAppear { viewModel.startGame() }
     }
 


### PR DESCRIPTION
## Summary
- track consecutive correct answers in time attack mode
- show temporary combo banner for streaks of two or more

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894b74bf04c832f84895bfbdf39eaf7