### PR TITLE
Toggle score and correct count displays by game mode

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -30,7 +30,15 @@ struct GameScene: View {
                     .padding(.top, 16)
 
                 HStack {
-                    Text("Score: \(viewModel.score)")
+                    if mode == .timeAttack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Score: \(viewModel.score)")
+                            if let delta = viewModel.scoreDelta {
+                                Text((delta > 0 ? "+\(delta)" : "\(delta)") + "点")
+                                    .foregroundColor(delta > 0 ? .green : .red)
+                            }
+                        }
+                    }
                     Spacer()
                     Text("Time: \(viewModel.timeRemaining)")
                 }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -64,8 +64,6 @@ struct ResultView: View {
                                 .padding(.top, 10)
                         }
                     case .correctCount:
-                        Text("\(correctCount)問正解")
-                            .font(.title2)
                         Text("時間: \(time)秒")
                             .font(.title2)
                     case .noMistake:


### PR DESCRIPTION
## Summary
- Show score and delta only during Time Attack games
- Hide correct count on result screen for Correct Count mode

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894b8649844832f95377bd27e27139f