### PR TITLE
Delay feedback reset and stabilize score layout

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -172,8 +172,10 @@ final class GameSceneViewModel: ObservableObject {
                 return
             }
 
-            feedback = nil
             problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                self.feedback = nil
+            }
         } else {
             feedback = .wrong
             incorrectCount += 1
@@ -196,7 +198,9 @@ final class GameSceneViewModel: ObservableObject {
 
             // Do not change the problem; reset only user input and feedback
             userInput = ""
-            feedback = nil
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                self.feedback = nil
+            }
         }
     }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -36,11 +36,23 @@ struct GameScene: View {
                             if let delta = viewModel.scoreDelta {
                                 Text((delta > 0 ? "+\(delta)" : "\(delta)") + "点")
                                     .foregroundColor(delta > 0 ? .green : .red)
+                            } else {
+                                Text(" ")
+                                    .hidden()
                             }
                         }
                     }
                     Spacer()
-                    Text("Time: \(viewModel.timeRemaining)")
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("Time: \(viewModel.timeRemaining)")
+                        if let delta = viewModel.timeDelta {
+                            Text((delta > 0 ? "+\(delta)" : "\(delta)") + "秒")
+                                .foregroundColor(delta > 0 ? .green : .red)
+                        } else {
+                            Text(" ")
+                                .hidden()
+                        }
+                    }
                 }
                 .font(.title2)
                 .padding(.top, 8)


### PR DESCRIPTION
## Summary
- Keep correct/incorrect feedback visible for 0.6 seconds before clearing
- Add hidden placeholders for score and time deltas to prevent keypad shifting

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6894bd723024832fb18632e86dad8723