### PR TITLE
Require difficulty and question style selection

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -36,6 +36,7 @@ struct ContentView: View {
                 selectedStyle: $selectedStyle,
                 currentScreen: $currentScreen,
                 startGame: {
+                    guard selectedDifficulty != nil, selectedStyle != nil else { return }
                     currentScreen = .ready
                 }
             )

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -25,9 +25,9 @@ struct DifficultySelectView: View {
                 VStack(spacing: 10) {
                     Text("出題形式")
                     HStack(spacing: 20) {
-                        styleButton(title: "単一演算", style: .single)
-                        styleButton(title: "連続演算", style: .sequence)
-                        styleButton(title: "ランダム", style: .mixed)
+                        styleButton(title: "1つずつ出題", style: .single)
+                        styleButton(title: "続けて計算", style: .sequence)
+                        styleButton(title: "ランダム出題", style: .mixed)
                     }
                 }
             }
@@ -38,9 +38,10 @@ struct DifficultySelectView: View {
                     .font(.title2)
                     .frame(maxWidth: .infinity)
                     .padding()
-                    .background(Color.blue.opacity(0.2))
+                    .background((selectedDifficulty != nil && selectedStyle != nil) ? Color.blue.opacity(0.2) : Color.gray.opacity(0.2))
                     .cornerRadius(8)
             }
+            .disabled(selectedDifficulty == nil || selectedStyle == nil)
             .contentShape(Rectangle())
             .padding(.horizontal, 40)
 


### PR DESCRIPTION
## Summary
- disable start button until difficulty and question style are chosen
- clarify question style labels for easier understanding

## Testing
- `swift test` (fails: Could not find Package.swift)

------
https://chatgpt.com/codex/tasks/task_e_689609e112bc832f9e450060743c548d