### PR TITLE
Implement question style logic for arithmetic problems

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -48,6 +48,7 @@ struct ContentView: View {
             GameScene(
                 difficulty: selectedDifficulty ?? .easy,
                 mode: selectedMode ?? .timeAttack,
+                style: selectedStyle ?? .single,
                 currentScreen: $currentScreen,
                 onGameEnd: { score, correct, incorrect, time in
                     finalScore = score

--- a/ath-speed-trainer/ath-speed-trainer/GameLogic/ProblemGenerator.swift
+++ b/ath-speed-trainer/ath-speed-trainer/GameLogic/ProblemGenerator.swift
@@ -1,8 +1,23 @@
 import Foundation
 
-/// Generates arithmetic problems based on the selected difficulty and current score.
+/// Generates arithmetic problems based on the selected difficulty, score, and question style.
 struct ProblemGenerator {
-    static func generate(difficulty: Difficulty, score: Int) -> ArithmeticProblem {
+    static func generate(difficulty: Difficulty, score: Int, style: QuestionStyle) -> ArithmeticProblem {
+        switch style {
+        case .single:
+            return generateSingleProblem(difficulty: difficulty, score: score)
+        case .sequence:
+            return generateSequenceProblem(difficulty: difficulty, score: score)
+        case .mixed:
+            return Bool.random()
+                ? generateSingleProblem(difficulty: difficulty, score: score)
+                : generateSequenceProblem(difficulty: difficulty, score: score)
+        }
+    }
+
+    // MARK: - Single Operation Problems
+
+    private static func generateSingleProblem(difficulty: Difficulty, score: Int) -> ArithmeticProblem {
         let operations = ["+", "-", "×", "÷"]
         let op = operations.randomElement()!
 
@@ -15,8 +30,6 @@ struct ProblemGenerator {
             return generateHardProblem(op: op, score: score)
         }
     }
-
-    // MARK: - Private helpers
 
     private static func generateEasyProblem(op: String) -> ArithmeticProblem {
         switch op {
@@ -94,6 +107,123 @@ struct ProblemGenerator {
                 let a = b * ans
                 return ArithmeticProblem(question: "\(a) ÷ \(b)", answer: ans)
             }
+        }
+    }
+
+    // MARK: - Sequence Problems
+
+    private static func generateSequenceProblem(difficulty: Difficulty, score: Int) -> ArithmeticProblem {
+        let operations = ["+", "-", "×", "÷"]
+        let op1 = operations.randomElement()!
+        let op2 = operations.randomElement()!
+
+        var a: Int = 0
+        var b: Int = 0
+        var c: Int = 0
+        var answer: Int = 0
+
+        if precedence(of: op1) >= precedence(of: op2) {
+            (a, b) = generateOperands(for: op1, difficulty: difficulty, score: score)
+            let firstResult = apply(op1, a, b)
+            if op2 == "÷" {
+                let range = mulDivRange(for: difficulty, score: score)
+                var divisors = Array(range).filter { firstResult % $0 == 0 }
+                if divisors.isEmpty { divisors = [1] }
+                c = divisors.randomElement()!
+            } else {
+                c = randomOperand(for: op2, difficulty: difficulty, score: score)
+            }
+            answer = apply(op2, firstResult, c)
+        } else {
+            repeat {
+                (b, c) = generateOperands(for: op2, difficulty: difficulty, score: score)
+                answer = apply(op2, b, c)
+            } while op1 == "÷" && answer == 0
+
+            let secondResult = answer
+            if op1 == "÷" {
+                let range = mulDivRange(for: difficulty, score: score)
+                let multiplier = Int.random(in: range)
+                a = secondResult * multiplier
+                answer = apply(op1, a, secondResult)
+            } else {
+                a = randomOperand(for: op1, difficulty: difficulty, score: score)
+                answer = apply(op1, a, secondResult)
+            }
+        }
+
+        let question = "\(a) \(op1) \(b) \(op2) \(c)"
+        return ArithmeticProblem(question: question, answer: answer)
+    }
+
+    // MARK: - Helpers
+
+    private static func addSubRange(for difficulty: Difficulty) -> ClosedRange<Int> {
+        switch difficulty {
+        case .easy: return 1...9
+        case .normal: return 10...99
+        case .hard: return 100...999
+        }
+    }
+
+    private static func mulDivRange(for difficulty: Difficulty, score: Int) -> ClosedRange<Int> {
+        switch difficulty {
+        case .easy, .normal:
+            return 1...9
+        case .hard:
+            return score > 70 ? 10...99 : 1...9
+        }
+    }
+
+    private static func randomAddSubOperand(difficulty: Difficulty) -> Int {
+        Int.random(in: addSubRange(for: difficulty))
+    }
+
+    private static func randomMulDivOperand(difficulty: Difficulty, score: Int) -> Int {
+        Int.random(in: mulDivRange(for: difficulty, score: score))
+    }
+
+    private static func randomOperand(for op: String, difficulty: Difficulty, score: Int) -> Int {
+        switch op {
+        case "+", "-":
+            return randomAddSubOperand(difficulty: difficulty)
+        default:
+            return randomMulDivOperand(difficulty: difficulty, score: score)
+        }
+    }
+
+    private static func generateOperands(for op: String, difficulty: Difficulty, score: Int) -> (Int, Int) {
+        switch op {
+        case "+":
+            let a = randomAddSubOperand(difficulty: difficulty)
+            let b = randomAddSubOperand(difficulty: difficulty)
+            return (a, b)
+        case "-":
+            let a = randomAddSubOperand(difficulty: difficulty)
+            let b = randomAddSubOperand(difficulty: difficulty)
+            return (a, b)
+        case "×":
+            let a = randomMulDivOperand(difficulty: difficulty, score: score)
+            let b = randomMulDivOperand(difficulty: difficulty, score: score)
+            return (a, b)
+        default: // division
+            let b = randomMulDivOperand(difficulty: difficulty, score: score)
+            let ans = randomMulDivOperand(difficulty: difficulty, score: score)
+            let a = b * ans
+            return (a, b)
+        }
+    }
+
+    private static func precedence(of op: String) -> Int {
+        (op == "×" || op == "÷") ? 2 : 1
+    }
+
+    private static func apply(_ op: String, _ lhs: Int, _ rhs: Int) -> Int {
+        switch op {
+        case "+": return lhs + rhs
+        case "-": return lhs - rhs
+        case "×": return lhs * rhs
+        default: return lhs / rhs
         }
     }
 }

--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -23,16 +23,18 @@ final class GameSceneViewModel: ObservableObject {
 
     private let difficulty: Difficulty
     private let mode: GameMode
+    private let style: QuestionStyle
     private var timer: Timer?
     private let questionLimit = 10
     private var isGameOver = false
     private let onGameEnd: ((Int, Int, Int?, Int) -> Void)?
 
-    init(difficulty: Difficulty, mode: GameMode, onGameEnd: ((Int, Int, Int?, Int) -> Void)? = nil) {
+    init(difficulty: Difficulty, mode: GameMode, style: QuestionStyle, onGameEnd: ((Int, Int, Int?, Int) -> Void)? = nil) {
         self.difficulty = difficulty
         self.mode = mode
+        self.style = style
         self.onGameEnd = onGameEnd
-        self.problem = ProblemGenerator.generate(difficulty: difficulty, score: 0)
+        self.problem = ProblemGenerator.generate(difficulty: difficulty, score: 0, style: style)
     }
 
     func startGame() {
@@ -47,7 +49,7 @@ final class GameSceneViewModel: ObservableObject {
         showCombo = false
         isGameOver = false
         isPaused = false
-        problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
+        problem = ProblemGenerator.generate(difficulty: difficulty, score: score, style: style)
 
         switch mode {
         case .timeAttack:
@@ -172,7 +174,7 @@ final class GameSceneViewModel: ObservableObject {
                 return
             }
 
-            problem = ProblemGenerator.generate(difficulty: difficulty, score: score)
+            problem = ProblemGenerator.generate(difficulty: difficulty, score: score, style: style)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
                 self.feedback = nil
             }

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -8,8 +8,8 @@ struct GameScene: View {
     @State private var showPauseMenu = false
     @State private var countdown: Int = 0
 
-    init(difficulty: Difficulty, mode: GameMode, currentScreen: Binding<AppScreen>, onGameEnd: @escaping (Int, Int, Int?, Int) -> Void) {
-        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty, mode: mode, onGameEnd: onGameEnd))
+    init(difficulty: Difficulty, mode: GameMode, style: QuestionStyle, currentScreen: Binding<AppScreen>, onGameEnd: @escaping (Int, Int, Int?, Int) -> Void) {
+        _viewModel = StateObject(wrappedValue: GameSceneViewModel(difficulty: difficulty, mode: mode, style: style, onGameEnd: onGameEnd))
         self.mode = mode
         self._currentScreen = currentScreen
     }
@@ -240,5 +240,5 @@ struct GameScene: View {
 }
 
 #Preview {
-    GameScene(difficulty: .easy, mode: .timeAttack, currentScreen: .constant(.game), onGameEnd: { _,_,_,_ in })
+    GameScene(difficulty: .easy, mode: .timeAttack, style: .single, currentScreen: .constant(.game), onGameEnd: { _,_,_,_ in })
 }


### PR DESCRIPTION
## Summary
- Extend `ProblemGenerator` to support single, sequence, and mixed question styles with proper operator precedence.
- Thread selected question style through `GameScene` and `GameSceneViewModel` so generated problems respect user choice.
- Update UI construction to pass the chosen style into the game scene.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68960f673fc8832f8a2569fc9fe4f961