### PR TITLE
Unify Settings/Credit/BackButton with Cyber Theme

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
@@ -1,17 +1,31 @@
 import SwiftUI
 
 struct BackButton: View {
+    let title: String
     let action: () -> Void
+
+    init(title: String = "メニュー", action: @escaping () -> Void) {
+        self.title = title
+        self.action = action
+    }
 
     var body: some View {
         HStack {
             Button(action: action) {
-                Text("＜戻る") // ← 直接文字列で記述
-                    .font(DesignTokens.Typography.body)
-                    .padding(DesignTokens.Spacing.s)
-                    .background(DesignTokens.Colors.surface)
-                    .cornerRadius(DesignTokens.Radius.m)
-                    .foregroundColor(DesignTokens.Colors.onDark)
+                HStack(spacing: DesignTokens.Spacing.s) {
+                    Image(systemName: "chevron.left.circle.fill")
+                        .foregroundColor(DesignTokens.Colors.neonBlue)
+                    Text(title)
+                        .foregroundColor(DesignTokens.Colors.onDark)
+                }
+                .font(DesignTokens.Typography.body)
+                .padding(DesignTokens.Spacing.s)
+                .background(DesignTokens.Colors.surface)
+                .cornerRadius(DesignTokens.Radius.m)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                        .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                )
             }
             .contentShape(Rectangle())
             Spacer()

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -4,52 +4,64 @@ struct CreditView: View {
     @Binding var currentScreen: AppScreen
 
     var body: some View {
-        VStack(alignment: .leading, spacing: DesignTokens.Spacing.m + DesignTokens.Spacing.s) {
-            HStack {
-                Button(action: { currentScreen = .modeSelect }) {
-                    Text("メニューに戻る")
-                        .font(DesignTokens.Typography.body)
-                        .padding(DesignTokens.Spacing.s)
-                        .background(DesignTokens.Colors.surface)
-                        .cornerRadius(DesignTokens.Radius.m)
-                        .foregroundColor(DesignTokens.Colors.onDark)
-                }
-                .contentShape(Rectangle())
-                Spacer()
-            }
-            .padding(.top, DesignTokens.Spacing.l)
-            .padding(.leading, DesignTokens.Spacing.l)
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xl) {
+            BackButton { currentScreen = .modeSelect }
 
             ScrollView {
                 VStack(alignment: .leading, spacing: DesignTokens.Spacing.l) {
                     Text("Ath Speed Trainer")
                         .font(DesignTokens.Typography.title)
+                        .glow(DesignTokens.Colors.neonBlue)
 
-                    Group {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.s) {
                         Text("開発者")
                             .font(DesignTokens.Typography.body).bold()
                         Text("Keita Kobayashi")
                             .font(DesignTokens.Typography.body)
+                            .foregroundColor(DesignTokens.Colors.onMuted)
                     }
+                    .padding()
+                    .background(DesignTokens.Colors.surface)
+                    .cornerRadius(DesignTokens.Radius.m)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                            .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                    )
 
-                    Group {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.s) {
                         Text("使用素材")
                             .font(DesignTokens.Typography.body).bold()
                         Text("アイコン：Flaticon\n効果音：効果音ラボ")
                             .font(DesignTokens.Typography.body)
+                            .foregroundColor(DesignTokens.Colors.onMuted)
                             .multilineTextAlignment(.leading)
                     }
+                    .padding()
+                    .background(DesignTokens.Colors.surface)
+                    .cornerRadius(DesignTokens.Radius.m)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                            .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                    )
 
-                    Group {
+                    VStack(alignment: .leading, spacing: DesignTokens.Spacing.s) {
                         Text("ライセンス")
                             .font(DesignTokens.Typography.body).bold()
                         Text("このアプリはMITライセンスに基づいて公開されています。\n使用素材の著作権は各提供元に帰属します。")
                             .font(DesignTokens.Typography.body)
+                            .foregroundColor(DesignTokens.Colors.onMuted)
                             .multilineTextAlignment(.leading)
                     }
+                    .padding()
+                    .background(DesignTokens.Colors.surface)
+                    .cornerRadius(DesignTokens.Radius.m)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                            .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                    )
                 }
                 .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-                .padding(.bottom, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
+                .padding(.vertical, DesignTokens.Spacing.xl)
             }
         }
         .foregroundColor(DesignTokens.Colors.onDark)

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -7,41 +7,47 @@ struct SettingView: View {
     @AppStorage("isVibrationOn") private var isVibrationOn: Bool = true
 
     var body: some View {
-        VStack(spacing: DesignTokens.Spacing.m + DesignTokens.Spacing.s) {
-            HStack {
-                Button(action: { currentScreen = .modeSelect }) {
-                    Text("メニューに戻る")
-                        .font(DesignTokens.Typography.body)
-                        .padding(DesignTokens.Spacing.s)
-                        .background(DesignTokens.Colors.surface)
-                        .cornerRadius(DesignTokens.Radius.m)
-                        .foregroundColor(DesignTokens.Colors.onDark)
-                }
-                .contentShape(Rectangle())
-                Spacer()
-            }
-            .padding(.top, DesignTokens.Spacing.l)
-            .padding(.leading, DesignTokens.Spacing.l)
+        VStack(alignment: .leading, spacing: DesignTokens.Spacing.xl) {
+            BackButton { currentScreen = .modeSelect }
 
-
-            VStack(spacing: DesignTokens.Spacing.l + DesignTokens.Spacing.xl) {
+            VStack(alignment: .leading, spacing: DesignTokens.Spacing.l) {
                 Text("設定")
                     .font(DesignTokens.Typography.title)
+                    .underline(true, color: DesignTokens.Colors.neonBlue)
 
-                VStack(spacing: DesignTokens.Spacing.m + DesignTokens.Spacing.s) {
+                VStack(spacing: DesignTokens.Spacing.m) {
                     Toggle("BGM", isOn: $isBgmOn)
-                        .font(DesignTokens.Typography.title)
+                        .padding()
+                        .background(DesignTokens.Colors.surface)
+                        .cornerRadius(DesignTokens.Radius.m)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                                .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                        )
                     Toggle("効果音（SE）", isOn: $isSeOn)
-                        .font(DesignTokens.Typography.title)
+                        .padding()
+                        .background(DesignTokens.Colors.surface)
+                        .cornerRadius(DesignTokens.Radius.m)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                                .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                        )
                     Toggle("バイブレーション", isOn: $isVibrationOn)
-                        .font(DesignTokens.Typography.title)
+                        .padding()
+                        .background(DesignTokens.Colors.surface)
+                        .cornerRadius(DesignTokens.Radius.m)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
+                                .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
+                        )
                 }
-                .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
             }
 
             Spacer()
         }
         .foregroundColor(DesignTokens.Colors.onDark)
+        .padding(.vertical, DesignTokens.Spacing.xl)
+        .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
         .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
     }
 }


### PR DESCRIPTION
## Summary
- Style BackButton with neon-bordered chevron icon and menu label
- Apply cyber-themed heading and card toggles to settings screen
- Glow title and card sections in credit view for unified theme

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896295575bc832f8cdbb394a4099d4e