### PR TITLE
Refactor ModeSelectView for adaptive layout

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -5,47 +5,69 @@ struct ModeSelectView: View {
     @Binding var selectedMode: GameMode?
 
     var body: some View {
-        VStack(spacing: DesignTokens.Spacing.xl) {
-            Text("Ath Speed Trainer")
-                .font(DesignTokens.Typography.title)
-                .foregroundColor(DesignTokens.Colors.onDark)
-                .padding(.top, DesignTokens.Spacing.xl)
+        GeometryReader { geo in
+            let contentWidth = min(geo.size.width - 24 * 2, 420)
 
-            Text("モード選択")
-                .font(DesignTokens.Typography.title)
-                .foregroundColor(DesignTokens.Colors.onDark)
+            ScrollView {
+                VStack(spacing: DesignTokens.Spacing.l) {
+                    Text("Ath Speed Trainer")
+                        .font(DesignTokens.Typography.title)
+                        .foregroundColor(DesignTokens.Colors.onDark)
+                        .bold()
+                        .padding(.top, DesignTokens.Spacing.xl)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .frame(width: contentWidth)
 
-            VStack(spacing: DesignTokens.Spacing.m + DesignTokens.Spacing.s) {
-                modeButton(title: "タイムアタック", mode: .timeAttack)
-                modeButton(title: "10問正解タイムアタック", mode: .correctCount)
-                modeButton(title: "ミス耐久", mode: .noMistake)
+                    Text("モード選択")
+                        .font(DesignTokens.Typography.body)
+                        .foregroundColor(DesignTokens.Colors.onMuted)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        .frame(width: contentWidth)
+
+                    LazyVGrid(
+                        columns: [GridItem(.adaptive(minimum: 150, maximum: 220), spacing: DesignTokens.Spacing.m)],
+                        spacing: DesignTokens.Spacing.m
+                    ) {
+                        modeButton(title: "タイムアタック", mode: .timeAttack)
+                        modeButton(title: "10問正解タイムアタック", mode: .correctCount)
+                        modeButton(title: "ミス耐久", mode: .noMistake)
+                    }
+                    .frame(width: contentWidth)
+
+                    LazyVGrid(
+                        columns: [GridItem(.adaptive(minimum: 150, maximum: 220), spacing: DesignTokens.Spacing.m)],
+                        spacing: DesignTokens.Spacing.m
+                    ) {
+                        menuButton(title: "設定", screen: .setting)
+                        menuButton(title: "クレジット", screen: .credit)
+                    }
+                    .frame(width: contentWidth)
+                    .padding(.bottom, DesignTokens.Spacing.xl)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 24)
             }
-            .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-
-            Spacer()
-
-            VStack(spacing: DesignTokens.Spacing.m + DesignTokens.Spacing.s) {
-                menuButton(title: "設定", screen: .setting)
-                menuButton(title: "クレジット", screen: .credit)
-            }
-            .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-            .padding(.bottom, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
+            .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
         }
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
     }
 
     private func modeButton(title: String, mode: GameMode) -> some View {
-        Button(action: {
+        Button {
             selectedMode = nil
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                selectedMode = mode
-            }
-        }) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { selectedMode = mode }
+        } label: {
             Text(title)
                 .font(DesignTokens.Typography.title)
                 .bold()
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
         }
         .buttonStyle(HologramButtonStyle())
+        .frame(minWidth: 150, maxWidth: .infinity, minHeight: 56)
+        .contentShape(Rectangle())
     }
 
     private func menuButton(title: String, screen: AppScreen) -> some View {
@@ -53,8 +75,13 @@ struct ModeSelectView: View {
             Text(title)
                 .font(DesignTokens.Typography.body)
                 .bold()
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
         }
         .buttonStyle(HologramButtonStyle())
+        .frame(minWidth: 150, maxWidth: .infinity, minHeight: 56)
+        .contentShape(Rectangle())
     }
 }
 
@@ -66,7 +93,7 @@ struct HologramButtonStyle: ButtonStyle {
         let radius: CGFloat = (isSelected || configuration.isPressed) ? 12 : 6
 
         return configuration.label
-            .frame(maxWidth: .infinity, minWidth: 120, minHeight: 56)
+            .frame(minWidth: 120, maxWidth: .infinity, minHeight: 56)
             .padding(DesignTokens.Spacing.m)
             .background(DesignTokens.Colors.surface)
             .overlay(
@@ -78,6 +105,7 @@ struct HologramButtonStyle: ButtonStyle {
             .glow(color, radius: radius)
             .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
             .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+            .padding(.horizontal, 2)
     }
 }
 


### PR DESCRIPTION
## Summary
- Wrap mode selection UI in GeometryReader and ScrollView to compute a safe `contentWidth`
- Use adaptive `LazyVGrid` and scalable text to prevent clipping on narrow devices
- Tweak `HologramButtonStyle` frame ordering and padding to avoid neon glow clipping

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild -version` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6896342e0d90832f9f65d1f90d48a8bc