### PR TITLE
feat: support full-screen background image

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -78,7 +78,7 @@ struct ContentView: View {
         }
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/AppBackground.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/AppBackground.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// 共通の全画面背景画像
+struct AppBackground: View {
+    var body: some View {
+        Image("haikei")
+            .resizable()
+            .scaledToFill()
+            .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    AppBackground()
+}

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -65,7 +65,7 @@ struct CreditView: View {
             }
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -11,7 +11,7 @@ struct DifficultySelectView: View {
 
     var body: some View {
         ZStack {
-            DesignTokens.Colors.backgroundDark.ignoresSafeArea()
+            AppBackground()
 
             VStack(spacing: 0) {
                 // 左上：メニューへ戻る

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -245,7 +245,7 @@ struct GameScene: View {
 
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
         .animation(.easeInOut, value: viewModel.comboCount)
         .onAppear { viewModel.startGame() }
     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -31,7 +31,7 @@ struct ModeSelectView: View {
             .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
             .padding(.bottom, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
         }
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
     }
 
     private func modeButton(title: String, mode: GameMode) -> some View {

--- a/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
@@ -16,7 +16,7 @@ struct ReadyCountdownView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .foregroundColor(DesignTokens.Colors.neonBlue)
             .glow(DesignTokens.Colors.neonBlue)
-            .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+            .background(AppBackground())
             .onAppear(perform: startCountdown)
     }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -139,7 +139,7 @@ struct ResultView: View {
             Spacer()
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -48,7 +48,7 @@ struct SettingView: View {
         .foregroundColor(DesignTokens.Colors.onDark)
         .padding(.vertical, DesignTokens.Spacing.xl)
         .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .background(AppBackground())
     }
 }
 


### PR DESCRIPTION
## Summary
- add `AppBackground` view rendering `haikei` full-screen
- use `AppBackground` across main screens so background image stays behind content

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689644f1a020832f8123205b7fccb308