### PR TITLE
Apply shared background image with dark overlay

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -78,7 +78,7 @@ struct ContentView: View {
         }
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/BackgroundView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/BackgroundView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// 画面全体に適用する共通背景ビュー
+struct BackgroundView: View {
+    var body: some View {
+        Image("haikei")
+            .resizable()
+            .scaledToFill()
+            .ignoresSafeArea()
+            .overlay(Color.black.opacity(0.5).ignoresSafeArea())
+    }
+}
+
+extension View {
+    /// アプリ共通の背景画像とオーバーレイを適用
+    func appBackground() -> some View {
+        self.background(BackgroundView())
+    }
+}

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -65,7 +65,7 @@ struct CreditView: View {
             }
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -11,7 +11,7 @@ struct DifficultySelectView: View {
 
     var body: some View {
         ZStack {
-            DesignTokens.Colors.backgroundDark.ignoresSafeArea()
+            BackgroundView()
 
             VStack(spacing: 0) {
                 // 左上：メニューへ戻る

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -245,7 +245,7 @@ struct GameScene: View {
 
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
         .animation(.easeInOut, value: viewModel.comboCount)
         .onAppear { viewModel.startGame() }
     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -31,7 +31,7 @@ struct ModeSelectView: View {
             .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
             .padding(.bottom, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
         }
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 
     private func modeButton(title: String, mode: GameMode) -> some View {

--- a/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
@@ -16,7 +16,7 @@ struct ReadyCountdownView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .foregroundColor(DesignTokens.Colors.neonBlue)
             .glow(DesignTokens.Colors.neonBlue)
-            .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+            .appBackground()
             .onAppear(perform: startCountdown)
     }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -139,7 +139,7 @@ struct ResultView: View {
             Spacer()
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -48,7 +48,7 @@ struct SettingView: View {
         .foregroundColor(DesignTokens.Colors.onDark)
         .padding(.vertical, DesignTokens.Spacing.xl)
         .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 


### PR DESCRIPTION
## Summary
- Introduce `BackgroundView` that scales the `haikei` image to fill the screen and applies a dark translucent overlay
- Replace previous solid color backgrounds with the shared background across all screens

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6899ee88b348832fb65b705f38b3bfff