### PR TITLE
Add reusable app background image

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Views/AppBackground.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/AppBackground.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// アプリ共通の背景（画像＋ダークオーバーレイ）
+struct AppBackground: View {
+    var body: some View {
+        ZStack {
+            Image("kaikei")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
+            // 可読性を保つためのダークオーバーレイ（調整可）
+            DesignTokens.Colors.backgroundDark
+                .opacity(0.45)
+                .ignoresSafeArea()
+        }
+    }
+}
+
+/// 既存Viewに簡単に適用するためのモディファイア
+extension View {
+    /// 画面全体に背景画像＋オーバーレイを敷く
+    func appBackground() -> some View {
+        self.background(AppBackground())
+    }
+}

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -65,7 +65,7 @@ struct CreditView: View {
             }
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -11,7 +11,6 @@ struct DifficultySelectView: View {
 
     var body: some View {
         ZStack {
-            DesignTokens.Colors.backgroundDark.ignoresSafeArea()
 
             VStack(spacing: 0) {
                 // 左上：メニューへ戻る
@@ -100,6 +99,7 @@ struct DifficultySelectView: View {
                 }
             }
         }
+        .appBackground()
     }
 
     private func difficultyButton(title: String, difficulty: Difficulty) -> some View {

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -245,7 +245,7 @@ struct GameScene: View {
 
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
         .animation(.easeInOut, value: viewModel.comboCount)
         .onAppear { viewModel.startGame() }
     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -31,7 +31,7 @@ struct ModeSelectView: View {
             .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
             .padding(.bottom, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
         }
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 
     private func modeButton(title: String, mode: GameMode) -> some View {

--- a/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ReadyCountdownView.swift
@@ -16,7 +16,7 @@ struct ReadyCountdownView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .foregroundColor(DesignTokens.Colors.neonBlue)
             .glow(DesignTokens.Colors.neonBlue)
-            .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+            .appBackground()
             .onAppear(perform: startCountdown)
     }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -139,7 +139,7 @@ struct ResultView: View {
             Spacer()
         }
         .foregroundColor(DesignTokens.Colors.onDark)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -48,7 +48,7 @@ struct SettingView: View {
         .foregroundColor(DesignTokens.Colors.onDark)
         .padding(.vertical, DesignTokens.Spacing.xl)
         .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
-        .background(DesignTokens.Colors.backgroundDark.ignoresSafeArea())
+        .appBackground()
     }
 }
 


### PR DESCRIPTION
## Summary
- add `AppBackground` view and `appBackground()` modifier for consistent image background
- replace solid color backgrounds in main views with `.appBackground()`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6899f4e7dd5c832fb0ad49e73a9854c9