### PR TITLE
Add title screen and unify back navigation label

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// アプリ全体の画面遷移を管理するトップレベルビュー
 struct ContentView: View {
     /// 現在表示中の画面
-    @State private var currentScreen: AppScreen = .modeSelect
+    @State private var currentScreen: AppScreen = .title
 
     /// 選択されたゲームモード
     @State private var selectedMode: GameMode?
@@ -23,6 +23,9 @@ struct ContentView: View {
     var body: some View {
         Group {
             switch currentScreen {
+        case .title:
+            TitleView(currentScreen: $currentScreen)
+
         case .modeSelect:
             ModeSelectView(currentScreen: $currentScreen, selectedMode: $selectedMode)
                 .onChange(of: selectedMode) { _, newValue in

--- a/ath-speed-trainer/ath-speed-trainer/Models/AppScreen.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Models/AppScreen.swift
@@ -1,4 +1,5 @@
 enum AppScreen {
+    case title
     case modeSelect
     case difficultySelect
     case ready

--- a/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/BackButton.swift
@@ -4,7 +4,7 @@ struct BackButton: View {
     let title: String
     let action: () -> Void
 
-    init(title: String = "メニュー", action: @escaping () -> Void) {
+    init(title: String = "モード選択に戻る", action: @escaping () -> Void) {
         self.title = title
         self.action = action
     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -13,10 +13,10 @@ struct DifficultySelectView: View {
         ZStack {
 
             VStack(spacing: 0) {
-                // 左上：メニューへ戻る
+                // 左上：モード選択に戻る
                 HStack {
                     Button(action: { currentScreen = .modeSelect }) {
-                        Text("メニューに戻る")
+                        Text("モード選択に戻る")
                             .font(DesignTokens.Typography.body)
                             .foregroundColor(DesignTokens.Colors.onDark)
                             .padding(DesignTokens.Spacing.s)

--- a/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/GameScene.swift
@@ -183,7 +183,7 @@ struct GameScene: View {
                     .cornerRadius(DesignTokens.Radius.m)
                     .foregroundColor(DesignTokens.Colors.onDark)
 
-                    Button("メニューに戻る") {
+                    Button("モード選択に戻る") {
                         viewModel.stopGame()
                         currentScreen = .modeSelect
                     }

--- a/ath-speed-trainer/ath-speed-trainer/Views/TitleView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/TitleView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TitleView: View {
+    @Binding var currentScreen: AppScreen
+
+    var body: some View {
+        ZStack {
+            Image("title_bg")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+
+            Text("Tap to Start")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundColor(.white.opacity(0.85))
+                .padding(.bottom, 40)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { currentScreen = .modeSelect }
+    }
+}
+
+#Preview {
+    TitleView(currentScreen: .constant(.title))
+}


### PR DESCRIPTION
## Summary
- Introduce a new TitleView with tappable background image and "Tap to Start" prompt
- Start app at the title screen and update screen routing for new AppScreen.title
- Standardize all back navigation labels to "モード選択に戻る" and reference a `title_bg` asset without bundling placeholder files

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6899fe750d70832fb75b7623939dbeb1