### PR TITLE
Limit vibration to answer results and play countdown on start

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -142,6 +142,10 @@ final class GameSceneViewModel: ObservableObject {
             feedback = .correct
             correctCount += 1
             SEManager.shared.play(.success)
+            // Vibrate only on correct answers when enabled
+            if isVibrationOn {
+                AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
+            }
             if mode == .timeAttack {
                 comboCount += 1
                 showCombo = comboCount >= 2

--- a/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/DifficultySelectView.swift
@@ -61,7 +61,8 @@ struct DifficultySelectView: View {
 
                         // MARK: ゲーム開始
                         Button(action: {
-                            SEManager.shared.play(.button)
+                            // Play the same sound as the countdown when starting the game
+                            SEManager.shared.play(.countdown)
                             startGame()
                         }) {
                             Text("ゲーム開始")


### PR DESCRIPTION
## Summary
- Vibrate only when answers are correct or incorrect, gated by vibration setting
- Start game button now plays countdown sound instead of generic button effect

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689a24a154ac832fadb16ec6baf66a1e