### PR TITLE
Remove vibration option and functionality

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ViewModels/GameSceneViewModel.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import AudioToolbox
 
 final class GameSceneViewModel: ObservableObject {
     @Published var problem: ArithmeticProblem
@@ -15,8 +14,6 @@ final class GameSceneViewModel: ObservableObject {
     @Published var isPaused: Bool = false
     @Published var comboCount: Int = 0
     @Published var showCombo: Bool = false
-
-    @AppStorage("isVibrationOn") private var isVibrationOn: Bool = true
 
     enum Feedback { case correct, wrong }
 
@@ -142,10 +139,6 @@ final class GameSceneViewModel: ObservableObject {
             feedback = .correct
             correctCount += 1
             SEManager.shared.play(.success)
-            // Vibrate only on correct answers when enabled
-            if isVibrationOn {
-                AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
-            }
             if mode == .timeAttack {
                 comboCount += 1
                 showCombo = comboCount >= 2
@@ -186,9 +179,6 @@ final class GameSceneViewModel: ObservableObject {
             comboCount = 0
             showCombo = false
             SEManager.shared.play(.failure)
-            if isVibrationOn {
-                AudioServicesPlaySystemSound(kSystemSoundID_Vibrate)
-            }
             if mode == .timeAttack {
                 withAnimation {
                     score -= 5

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct SettingView: View {
     @Binding var currentScreen: AppScreen
     @AppStorage("isSeOn") private var isSeOn: Bool = true
-    @AppStorage("isVibrationOn") private var isVibrationOn: Bool = true
 
     var body: some View {
         VStack(alignment: .leading, spacing: DesignTokens.Spacing.xl) {
@@ -16,14 +15,6 @@ struct SettingView: View {
 
                 VStack(spacing: DesignTokens.Spacing.m) {
                     Toggle("効果音（SE）", isOn: $isSeOn)
-                        .padding()
-                        .background(DesignTokens.Colors.surface)
-                        .cornerRadius(DesignTokens.Radius.m)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: DesignTokens.Radius.m)
-                                .stroke(DesignTokens.Colors.neonBlue, lineWidth: 1)
-                        )
-                    Toggle("バイブレーション", isOn: $isVibrationOn)
                         .padding()
                         .background(DesignTokens.Colors.surface)
                         .cornerRadius(DesignTokens.Radius.m)


### PR DESCRIPTION
## Summary
- remove vibration toggle and storage
- drop vibration logic and AudioToolbox import from game scene

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project ath-speed-trainer/ath-speed-trainer.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a28242464832f9214e8065014dea4