### PR TITLE
Add share button to share game results

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/AppConstants.swift
+++ b/ath-speed-trainer/ath-speed-trainer/AppConstants.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct AppConstants {
+    #if DEBUG
+    static let appStoreURL = URL(string: "https://apps.apple.com/app/idXXXXXXXXXX")!
+    #else
+    static let appStoreURL = URL(string: "https://apps.apple.com/app/idXXXXXXXXXX")!
+    #endif
+
+    static let shareButtonTitle = "共有する"
+}
+

--- a/ath-speed-trainer/ath-speed-trainer/SEManager.swift
+++ b/ath-speed-trainer/ath-speed-trainer/SEManager.swift
@@ -7,6 +7,7 @@ enum SESound: SystemSoundID {
     case success   = 1322  // Anticipate
     case failure   = 1053  // SIMToolkit NegativeACK
     case finish    = 1054  // SIMToolkit SMSReceived
+    case decide    = 1057  // SIMToolkit CallDrop
 }
 
 final class SEManager {

--- a/ath-speed-trainer/ath-speed-trainer/ShareSheet.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ShareSheet.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+


### PR DESCRIPTION
## Summary
- add `AppConstants` with App Store URL and share button label
- implement `ShareSheet` wrapper for pre-iOS16 sharing
- enable sharing of play results via new button on `ResultView`
- extend `SEManager` with `decide` sound for button tap

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d162fdc0832fb4244de902bea7bd