### PR TITLE
Add AdMob ads with configurable IDs and frequency controls

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer.xcodeproj/project.pbxproj
+++ b/ath-speed-trainer/ath-speed-trainer.xcodeproj/project.pbxproj
@@ -4,7 +4,11 @@
 	classes = {
 	};
 	objectVersion = 77;
-	objects = {
+        objects = {
+
+/* Begin PBXBuildFile section */
+                FDF218AAC09F71EE033A223E /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = 8045D07908F68CB762A09D88 /* GoogleMobileAds */; };
+/* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		9EEC6E692E3A625D00F1B965 /* PBXContainerItemProxy */ = {
@@ -48,13 +52,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		9EEC6E582E3A625A00F1B965 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                9EEC6E582E3A625A00F1B965 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                FDF218AAC09F71EE033A223E /* GoogleMobileAds in Frameworks */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		9EEC6E652E3A625D00F1B965 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -107,16 +112,17 @@
 			);
 			dependencies = (
 			);
-			fileSystemSynchronizedGroups = (
-				9EEC6E5D2E3A625A00F1B965 /* ath-speed-trainer */,
-			);
-			name = "ath-speed-trainer";
-			packageProductDependencies = (
-			);
-			productName = "ath-speed-trainer";
-			productReference = 9EEC6E5B2E3A625A00F1B965 /* ath-speed-trainer.app */;
-			productType = "com.apple.product-type.application";
-		};
+                        fileSystemSynchronizedGroups = (
+                                9EEC6E5D2E3A625A00F1B965 /* ath-speed-trainer */,
+                        );
+                        name = "ath-speed-trainer";
+                        packageProductDependencies = (
+                                8045D07908F68CB762A09D88 /* GoogleMobileAds */,
+                        );
+                        productName = "ath-speed-trainer";
+                        productReference = 9EEC6E5B2E3A625A00F1B965 /* ath-speed-trainer.app */;
+                        productType = "com.apple.product-type.application";
+                };
 		9EEC6E672E3A625D00F1B965 /* ath-speed-trainerTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9EEC6E7F2E3A625D00F1B965 /* Build configuration list for PBXNativeTarget "ath-speed-trainerTests" */;
@@ -189,22 +195,25 @@
 			buildConfigurationList = 9EEC6E562E3A625A00F1B965 /* Build configuration list for PBXProject "ath-speed-trainer" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = 9EEC6E522E3A625900F1B965;
-			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
-			productRefGroup = 9EEC6E5C2E3A625A00F1B965 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				9EEC6E5A2E3A625A00F1B965 /* ath-speed-trainer */,
-				9EEC6E672E3A625D00F1B965 /* ath-speed-trainerTests */,
-				9EEC6E712E3A625D00F1B965 /* ath-speed-trainerUITests */,
-			);
-		};
+                        knownRegions = (
+                                en,
+                                Base,
+                        );
+                        mainGroup = 9EEC6E522E3A625900F1B965;
+                        minimizedProjectReferenceProxies = 1;
+                        preferredProjectObjectVersion = 77;
+                        productRefGroup = 9EEC6E5C2E3A625A00F1B965 /* Products */;
+                        projectDirPath = "";
+                        projectRoot = "";
+                        packageReferences = (
+                                9037A1285A80444EFE27A36C /* swift-package-manager-google-mobile-ads */,
+                        );
+                        targets = (
+                                9EEC6E5A2E3A625A00F1B965 /* ath-speed-trainer */,
+                                9EEC6E672E3A625D00F1B965 /* ath-speed-trainerTests */,
+                                9EEC6E712E3A625D00F1B965 /* ath-speed-trainerUITests */,
+                        );
+                };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -393,16 +402,19 @@
 		9EEC6E7D2E3A625D00F1B965 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G9BUXBTRYK;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = G9BUXBTRYK;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                GAD_APPLICATION_ID = "ca-app-pub-3940256099942544~1458002511";
+                                INFOPLIST_KEY_GADApplicationIdentifier = "$(GAD_APPLICATION_ID)";
+                                INFOPLIST_KEY_NSUserTrackingUsageDescription = "広告提供のためにデバイス識別子を使用します";
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -421,16 +433,19 @@
 		9EEC6E7E2E3A625D00F1B965 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = G9BUXBTRYK;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+                                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                                ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+                                CODE_SIGN_STYLE = Automatic;
+                                CURRENT_PROJECT_VERSION = 1;
+                                DEVELOPMENT_TEAM = G9BUXBTRYK;
+                                ENABLE_PREVIEWS = YES;
+                                GENERATE_INFOPLIST_FILE = YES;
+                                GAD_APPLICATION_ID = "ca-app-pub-XXXXXXXX~YYYYYYYY";
+                                INFOPLIST_KEY_GADApplicationIdentifier = "$(GAD_APPLICATION_ID)";
+                                INFOPLIST_KEY_NSUserTrackingUsageDescription = "広告提供のためにデバイス識別子を使用します";
+                                INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+                                INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+                                INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -548,16 +563,32 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9EEC6E822E3A625D00F1B965 /* Build configuration list for PBXNativeTarget "ath-speed-trainerUITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				9EEC6E832E3A625D00F1B965 /* Debug */,
-				9EEC6E842E3A625D00F1B965 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+                9EEC6E822E3A625D00F1B965 /* Build configuration list for PBXNativeTarget "ath-speed-trainerUITests" */ = {
+                        isa = XCConfigurationList;
+                        buildConfigurations = (
+                                9EEC6E832E3A625D00F1B965 /* Debug */,
+                                9EEC6E842E3A625D00F1B965 /* Release */,
+                        );
+                        defaultConfigurationIsVisible = 0;
+                        defaultConfigurationName = Release;
+                };
 /* End XCConfigurationList section */
-	};
-	rootObject = 9EEC6E532E3A625900F1B965 /* Project object */;
+
+/* Begin XCRemoteSwiftPackageReference section */
+                9037A1285A80444EFE27A36C /* swift-package-manager-google-mobile-ads */ = {
+                        isa = XCRemoteSwiftPackageReference;
+                        repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
+                        requirement = { kind = upToNextMajorVersion; minimumVersion = 11.9.0; };
+                };
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+                8045D07908F68CB762A09D88 /* GoogleMobileAds */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        productName = GoogleMobileAds;
+                        package = 9037A1285A80444EFE27A36C /* swift-package-manager-google-mobile-ads */;
+                };
+/* End XCSwiftPackageProductDependency section */
+        };
+        rootObject = 9EEC6E532E3A625900F1B965 /* Project object */;
 }

--- a/ath-speed-trainer/ath-speed-trainer/Ads/AdBannerView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Ads/AdBannerView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import GoogleMobileAds
+
+struct AdBannerView: View {
+    @State private var height: CGFloat? = nil
+
+    var body: some View {
+        if AdConfig.isAdsEnabled {
+            BannerContainer(height: $height)
+                .frame(height: height)
+        }
+    }
+
+    private struct BannerContainer: UIViewRepresentable {
+        @Binding var height: CGFloat?
+
+        func makeCoordinator() -> Coordinator {
+            Coordinator(self)
+        }
+
+        func makeUIView(context: Context) -> GADBannerView {
+            let size = UIDevice.current.userInterfaceIdiom == .pad ? GADAdSizeLargeBanner : GADAdSizeBanner
+            let view = GADBannerView(adSize: size)
+            view.adUnitID = AdConfig.bannerUnitID
+            view.rootViewController = UIApplication.shared.connectedScenes
+                .compactMap { ($0 as? UIWindowScene)?.windows.first { $0.isKeyWindow } }
+                .first?.rootViewController
+            view.delegate = context.coordinator
+            view.load(GADRequest())
+            return view
+        }
+
+        func updateUIView(_ uiView: GADBannerView, context: Context) {}
+
+        final class Coordinator: NSObject, GADBannerViewDelegate {
+            private let parent: BannerContainer
+            init(_ parent: BannerContainer) {
+                self.parent = parent
+            }
+
+            func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
+                parent.height = bannerView.bounds.height
+                #if DEBUG
+                print("Banner loaded")
+                #endif
+            }
+
+            func bannerView(_ bannerView: GADBannerView, didFailToReceiveAdWithError error: Error) {
+                parent.height = 0
+                #if DEBUG
+                print("Banner failed: \(error.localizedDescription)")
+                #endif
+            }
+        }
+    }
+}

--- a/ath-speed-trainer/ath-speed-trainer/Ads/AdConfig.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Ads/AdConfig.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct AdConfig {
+    static let isAdsEnabled = true
+
+    #if DEBUG
+    static let appID = "ca-app-pub-3940256099942544~1458002511"
+    static let bannerUnitID = "ca-app-pub-3940256099942544/2934735716"
+    static let interstitialUnitID = "ca-app-pub-3940256099942544/4411468910"
+    #else
+    static let appID = "ca-app-pub-XXXXXXXX~YYYYYYYY"
+    static let bannerUnitID = "ca-app-pub-XXXXXXXX/BBBBBBBB"
+    static let interstitialUnitID = "ca-app-pub-XXXXXXXX/IIIIIIII"
+    #endif
+
+    static let frequencyN = 3
+}

--- a/ath-speed-trainer/ath-speed-trainer/Ads/InterstitialAdCoordinator.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Ads/InterstitialAdCoordinator.swift
@@ -1,0 +1,78 @@
+import GoogleMobileAds
+import UIKit
+
+final class InterstitialAdCoordinator: NSObject, GADFullScreenContentDelegate {
+    static let shared = InterstitialAdCoordinator()
+
+    private var interstitial: GADInterstitialAd?
+    private var hitCount = 0
+    private var displayedLastTime = false
+    private var completion: (() -> Void)?
+
+    func preload() {
+        guard AdConfig.isAdsEnabled else { return }
+        #if DEBUG
+        print("Interstitial preload")
+        #endif
+        GADInterstitialAd.load(withAdUnitID: AdConfig.interstitialUnitID, request: GADRequest()) { [weak self] ad, error in
+            guard let self else { return }
+            if let ad = ad {
+                self.interstitial = ad
+                ad.fullScreenContentDelegate = self
+                #if DEBUG
+                print("Interstitial loaded")
+                #endif
+            } else {
+                #if DEBUG
+                print("Interstitial failed: \(error?.localizedDescription ?? "unknown error")")
+                #endif
+            }
+        }
+    }
+
+    func show(from rootViewController: UIViewController?, completion: @escaping () -> Void) {
+        guard AdConfig.isAdsEnabled else {
+            completion()
+            return
+        }
+
+        if displayedLastTime {
+            displayedLastTime = false
+            completion()
+            return
+        }
+
+        hitCount += 1
+        guard hitCount % AdConfig.frequencyN == 0,
+              let interstitial = interstitial,
+              let rootViewController = rootViewController else {
+            completion()
+            return
+        }
+
+        self.completion = completion
+        #if DEBUG
+        print("Interstitial present")
+        #endif
+        interstitial.present(fromRootViewController: rootViewController)
+    }
+
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        displayedLastTime = true
+        completion?()
+        completion = nil
+        interstitial = nil
+        preload()
+    }
+
+    func ad(_ ad: GADFullScreenPresentingAd, didFailToPresentFullScreenContentWithError error: Error) {
+        #if DEBUG
+        print("Interstitial presentation failed: \(error.localizedDescription)")
+        #endif
+        completion?()
+        completion = nil
+        interstitial = nil
+        displayedLastTime = false
+        preload()
+    }
+}

--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// アプリ全体の画面遷移を管理するトップレベルビュー
 struct ContentView: View {
@@ -59,7 +60,12 @@ struct ContentView: View {
                     correctCount = correct
                     incorrectCount = incorrect ?? 0
                     elapsedTime = time
-                    currentScreen = .result
+                    let root = UIApplication.shared.connectedScenes
+                        .compactMap { ($0 as? UIWindowScene)?.windows.first { $0.isKeyWindow } }
+                        .first?.rootViewController
+                    InterstitialAdCoordinator.shared.show(from: root) {
+                        currentScreen = .result
+                    }
                 }
             )
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ModeSelectView.swift
@@ -39,6 +39,10 @@ struct ModeSelectView: View {
             }
             .appBackground()
         }
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView()
+                .padding(.top, 8)
+        }
     }
 
     // モードボタン（大）

--- a/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/ResultView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Button Style
 struct StartButtonStyle: ButtonStyle {
@@ -194,7 +195,14 @@ struct ResultView: View {
 
             // アクション
             VStack(spacing: DesignTokens.Spacing.m) {
-                Button(action: { currentScreen = .ready }) {
+                Button(action: {
+                    let root = UIApplication.shared.connectedScenes
+                        .compactMap { ($0 as? UIWindowScene)?.windows.first { $0.isKeyWindow } }
+                        .first?.rootViewController
+                    InterstitialAdCoordinator.shared.show(from: root) {
+                        currentScreen = .ready
+                    }
+                }) {
                     Text("もう一度プレイ")
                         .font(DesignTokens.Typography.title)
                 }
@@ -236,6 +244,10 @@ struct ResultView: View {
         }
         .foregroundColor(DesignTokens.Colors.onDark)
         .appBackground()
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView()
+                .padding(.top, 8)
+        }
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/TitleView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/TitleView.swift
@@ -28,6 +28,10 @@ struct TitleView: View {
         
             currentScreen = .modeSelect
         }
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView()
+                .padding(.top, 8)
+        }
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ath_speed_trainerApp.swift
@@ -6,9 +6,21 @@
 //
 
 import SwiftUI
+import GoogleMobileAds
 
 @main
 struct ath_speed_trainerApp: App {
+
+    init() {
+        if AdConfig.isAdsEnabled {
+            GADMobileAds.sharedInstance().start(completionHandler: nil)
+            #if DEBUG
+            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [GADSimulatorID]
+            #endif
+            InterstitialAdCoordinator.shared.preload()
+        }
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- integrate GoogleMobileAds via Swift Package Manager and configure app & unit IDs per build
- display banner ads on title, mode-select, and result screens with a SwiftUI wrapper
- manage interstitial ads with frequency control and show after games or before replay

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d6dd76c0832fb0413a483998b792