### PR TITLE
Add AdMob banners to settings and credits and improve banner sizing

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/Ads/AdBannerView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Ads/AdBannerView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import GoogleMobileAds
+import UIKit
 
 struct AdBannerView: View {
     @State private var height: CGFloat? = nil
@@ -7,6 +8,7 @@ struct AdBannerView: View {
     var body: some View {
         if AdConfig.isAdsEnabled {
             BannerContainer(height: $height)
+                .frame(maxWidth: .infinity)
                 .frame(height: height)
         }
     }
@@ -19,7 +21,7 @@ struct AdBannerView: View {
         }
 
         func makeUIView(context: Context) -> GADBannerView {
-            let size = UIDevice.current.userInterfaceIdiom == .pad ? GADAdSizeLargeBanner : GADAdSizeBanner
+            let size = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(UIScreen.main.bounds.width)
             let view = GADBannerView(adSize: size)
             view.adUnitID = AdConfig.bannerUnitID
             view.rootViewController = UIApplication.shared.connectedScenes
@@ -30,7 +32,13 @@ struct AdBannerView: View {
             return view
         }
 
-        func updateUIView(_ uiView: GADBannerView, context: Context) {}
+        func updateUIView(_ uiView: GADBannerView, context: Context) {
+            let size = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(UIScreen.main.bounds.width)
+            if uiView.adSize.size.width != size.size.width {
+                uiView.adSize = size
+                uiView.load(GADRequest())
+            }
+        }
 
         final class Coordinator: NSObject, GADBannerViewDelegate {
             private let parent: BannerContainer

--- a/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/CreditView.swift
@@ -50,6 +50,10 @@ struct CreditView: View {
         }
         .foregroundColor(DesignTokens.Colors.onDark)
         .appBackground()
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView()
+                .padding(.top, 8)
+        }
     }
 }
 

--- a/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/Views/SettingView.swift
@@ -31,6 +31,10 @@ struct SettingView: View {
         .padding(.vertical, DesignTokens.Spacing.xl)
         .padding(.horizontal, DesignTokens.Spacing.l + DesignTokens.Spacing.xl)
         .appBackground()
+        .safeAreaInset(edge: .bottom) {
+            AdBannerView()
+                .padding(.top, 8)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- show AdMob banner at bottom of settings and credits
- ensure banner uses adaptive size and stretches full width

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dce17b28832fa5f10523e4c817b0