### PR TITLE
Delay interstitial ad until result screen

### DIFF
--- a/ath-speed-trainer/ath-speed-trainer/ContentView.swift
+++ b/ath-speed-trainer/ath-speed-trainer/ContentView.swift
@@ -60,12 +60,7 @@ struct ContentView: View {
                     correctCount = correct
                     incorrectCount = incorrect ?? 0
                     elapsedTime = time
-                    let root = UIApplication.shared.connectedScenes
-                        .compactMap { ($0 as? UIWindowScene)?.windows.first { $0.isKeyWindow } }
-                        .first?.rootViewController
-                    InterstitialAdCoordinator.shared.show(from: root) {
-                        currentScreen = .result
-                    }
+                    currentScreen = .result
                 }
             )
 


### PR DESCRIPTION
## Summary
- remove game-scene interstitial trigger and rely on ResultView to present ads
- schedule interstitial one second after ResultView appears with cancel on disappear

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e3869f6c832f8c3f8d1568de928d